### PR TITLE
feat: track failed file names in upload operations

### DIFF
--- a/src/config/WorkspaceConfig.ts
+++ b/src/config/WorkspaceConfig.ts
@@ -2,6 +2,13 @@ import fs from 'fs';
 import path from 'path';
 import { z } from 'zod';
 
+export const FailedFileSchema = z.object({
+  file: z.string(),
+  error: z.string(),
+});
+
+export type FailedFile = z.infer<typeof FailedFileSchema>;
+
 export const UploadOperationSchema = z.object({
   id: z.string(),
   status: z.enum(['pending', 'in_progress', 'completed', 'failed']),
@@ -12,6 +19,7 @@ export const UploadOperationSchema = z.object({
   completedFiles: z.number(),
   skippedFiles: z.number(),
   failedFiles: z.number(),
+  failedFilesList: z.array(FailedFileSchema).default([]),
   startedAt: z.string(),
   completedAt: z.string().optional(),
   error: z.string().optional(),

--- a/src/file-search/UploadOperationManager.test.ts
+++ b/src/file-search/UploadOperationManager.test.ts
@@ -176,4 +176,44 @@ describe('UploadOperationManager', () => {
       expect(updated?.failedFiles).toBe(2);
     });
   });
+
+  describe('addFailedFile', () => {
+    it('should add a failed file to the list', () => {
+      const operation = manager.createOperation('/path', 'store', false);
+
+      const updated = manager.addFailedFile(operation.id, 'test.txt', 'Upload failed');
+
+      expect(updated?.failedFiles).toBe(1);
+      expect(updated?.failedFilesList).toEqual([
+        { file: 'test.txt', error: 'Upload failed' }
+      ]);
+    });
+
+    it('should append multiple failed files', () => {
+      const operation = manager.createOperation('/path', 'store', false);
+
+      manager.addFailedFile(operation.id, 'file1.txt', 'Error 1');
+      const updated = manager.addFailedFile(operation.id, 'file2.txt', 'Error 2');
+
+      expect(updated?.failedFiles).toBe(2);
+      expect(updated?.failedFilesList).toEqual([
+        { file: 'file1.txt', error: 'Error 1' },
+        { file: 'file2.txt', error: 'Error 2' }
+      ]);
+    });
+
+    it('should return undefined for non-existent operation', () => {
+      const updated = manager.addFailedFile('non-existent-id', 'test.txt', 'Error');
+
+      expect(updated).toBeUndefined();
+    });
+  });
+
+  describe('createOperation', () => {
+    it('should initialize failedFilesList as empty array', () => {
+      const operation = manager.createOperation('/path', 'store', false);
+
+      expect(operation.failedFilesList).toEqual([]);
+    });
+  });
 });

--- a/src/file-search/UploadOperationManager.ts
+++ b/src/file-search/UploadOperationManager.ts
@@ -1,5 +1,5 @@
 import * as crypto from 'crypto';
-import { WorkspaceConfigManager, UploadOperation } from '../config/WorkspaceConfig';
+import { WorkspaceConfigManager, UploadOperation, FailedFile } from '../config/WorkspaceConfig';
 
 export class UploadOperationManager {
   /**
@@ -23,6 +23,7 @@ export class UploadOperationManager {
       completedFiles: 0,
       skippedFiles: 0,
       failedFiles: 0,
+      failedFilesList: [],
       startedAt: new Date().toISOString(),
     };
 
@@ -109,6 +110,22 @@ export class UploadOperationManager {
       completedFiles,
       skippedFiles,
       failedFiles,
+    });
+  }
+
+  /**
+   * Adds a failed file to the operation's failed files list.
+   */
+  addFailedFile(id: string, file: string, error: string): UploadOperation | undefined {
+    const existing = this.getOperation(id);
+    if (!existing) {
+      return undefined;
+    }
+
+    const failedFilesList = [...(existing.failedFilesList || []), { file, error }];
+    return this.updateOperation(id, {
+      failedFiles: failedFilesList.length,
+      failedFilesList,
     });
   }
 }


### PR DESCRIPTION
## Summary

Adds detailed tracking of failed files during upload operations so users can identify exactly which files failed and why.

**Problem:** When uploads complete with `completedFiles: 34` and `failedFiles: 1` out of `totalFiles: 35`, users had no way to know which file failed or why.

**Solution:** Track failed file names and error messages in a `failedFilesList` array.

## Changes

| File | Changes |
|------|---------|
| `src/config/WorkspaceConfig.ts` | Added `FailedFile` schema and `failedFilesList` to `UploadOperation` |
| `src/file-search/UploadOperationManager.ts` | Added `addFailedFile(id, file, error)` method |
| `src/index.ts` | Updated error handler to record failed files; include list in status output |
| `src/file-search/UploadOperationManager.test.ts` | Added tests for `addFailedFile` method |

## New Status Output

When files fail, the status now includes:
```json
{
  "progress": {
    "totalFiles": 35,
    "completedFiles": 34,
    "failedFiles": 1
  },
  "failedFilesList": [
    { "file": "problematic-file.bin", "error": "Unsupported file type" }
  ]
}
```

## Test plan

- [x] All 121 tests pass
- [x] Build succeeds
- [ ] Manual testing: trigger a file upload failure and verify the file appears in `failedFilesList`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Upload operations now track failed files with error messages, providing detailed visibility into which files failed and why during uploads.

* **Tests**
  * Added comprehensive tests for failed file tracking functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->