### PR TITLE
fix: resolve all ESLint warnings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,7 @@ server.registerTool(
     const operationId = operation.id;
 
     // Start the upload in the background (fire-and-forget)
-    (async () => {
+    (async (): Promise<void> => {
       try {
         if (stats.isDirectory()) {
           let completedFiles = 0;
@@ -141,9 +141,10 @@ server.registerTool(
           uploadOperationManager.markCompleted(operationId);
           console.error(`[${operationId}] Upload complete`);
         }
-      } catch (error: any) {
-        console.error(`[${operationId}] Upload failed:`, error.message);
-        uploadOperationManager.markFailed(operationId, error.message);
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`[${operationId}] Upload failed:`, message);
+        uploadOperationManager.markFailed(operationId, message);
       }
     })();
 
@@ -327,7 +328,7 @@ server.registerTool(
 
 // --- Start Server ---
 
-async function main() {
+async function main(): Promise<void> {
   const transport = new StdioServerTransport();
   // Ensure config file exists
   WorkspaceConfigManager.load();


### PR DESCRIPTION
## Summary
- Add explicit `Promise<void>` return types to async functions
- Replace `error: any` with `error: unknown` and use proper type guard

## Changes
- Line 99: IIFE now has explicit return type
- Line 144: Error handling uses `unknown` type with `instanceof Error` check
- Line 331: `main()` function has explicit return type

## Test plan
- [x] `npm run lint` passes with no warnings
- [x] `npm test` passes
- [x] `npm run build` succeeds