### PR TITLE
fix: handle 429 quota errors in research_start

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
 # gemini-deep-research
 A deep research extension for Gemini CLI
 
+## Requirements
+
+**A paid Google AI API key is required.** Deep Research uses the Gemini Interactions API, which has separate quota from standard Gemini model calls. Free-tier API keys do not have access and will receive a `429 Too Many Requests` quota error.
+
+Get a paid key from [Google AI Studio](https://aistudio.google.com/apikey) and ensure billing is enabled on your Google Cloud project.
+
 ## Configuration
 
-To use this extension, you must provide a Google GenAI API key. You can set it using one of the following environment variables (in order of priority):
+Set your API key using one of the following environment variables (in order of priority):
 
 1.  `GEMINI_DEEP_RESEARCH_API_KEY`
 2.  `GEMINI_API_KEY`

--- a/deep-research-GEMINI.md
+++ b/deep-research-GEMINI.md
@@ -2,6 +2,15 @@
 
 This extension provides tools for performing Deep Research and managing File Search stores for Retrieval Augmented Generation (RAG). It maintains a local workspace state to simplify the research workflow.
 
+## Requirements
+
+**A paid Google AI API key is required.** Deep Research uses the Gemini Interactions API, which has separate quota from standard Gemini model calls. Free-tier API keys do not have access to this feature and will receive a `429 Too Many Requests` quota error.
+
+To get a paid key:
+1. Go to [Google AI Studio](https://aistudio.google.com/apikey)
+2. Ensure billing is enabled on your Google Cloud project
+3. Set the key via `GEMINI_DEEP_RESEARCH_API_KEY` or `GEMINI_API_KEY` environment variable
+
 ## Workspace Caching
 
 The extension automatically manages a `.gemini-research.json` file in the current working directory. This file caches:

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -450,6 +450,46 @@ describe('MCP Server Tools', () => {
         fileSearchStoreNames: ['stores/1', 'stores/2'],
       });
     });
+
+    it('should return helpful message on 429 quota error', async () => {
+      mockStartResearch.mockRejectedValue(new Error('429 {"error":{"message":"You do not have enough quota to make this request.","code":"too_many_requests"}}'));
+
+      const result = await toolHandlers['research_start']({
+        input: 'Research topic',
+        model: 'deep-research-pro-preview-12-2025',
+      }) as McpToolResult;
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Deep Research quota error');
+      expect(result.content[0].text).toContain('paid Google AI API key');
+      expect(result.content[0].text).toContain('aistudio.google.com');
+    });
+
+    it('should return helpful message on generic quota error', async () => {
+      mockStartResearch.mockRejectedValue(new Error('quota exceeded'));
+
+      const result = await toolHandlers['research_start']({
+        input: 'Research topic',
+        model: 'deep-research-pro-preview-12-2025',
+      }) as McpToolResult;
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Deep Research quota error');
+    });
+
+    it('should return generic error for non-quota failures', async () => {
+      mockStartResearch.mockRejectedValue(new Error('Network connection failed'));
+
+      const result = await toolHandlers['research_start']({
+        input: 'Research topic',
+        model: 'deep-research-pro-preview-12-2025',
+      }) as McpToolResult;
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Research failed to start');
+      expect(result.content[0].text).toContain('Network connection failed');
+      expect(result.content[0].text).not.toContain('paid Google AI API key');
+    });
   });
 
   describe('research_status', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -271,20 +271,46 @@ server.registerTool(
       finalInput = `[Report Format: ${report_format}]\n\n${input}`;
     }
 
-    const interaction = await researchManager.startResearch({
-      input: finalInput,
-      model,
-      fileSearchStoreNames,
-    });
-    if (interaction.id) {
-        WorkspaceConfigManager.addResearchId(interaction.id);
+    try {
+      const interaction = await researchManager.startResearch({
+        input: finalInput,
+        model,
+        fileSearchStoreNames,
+      });
+      if (interaction.id) {
+          WorkspaceConfigManager.addResearchId(interaction.id);
+      }
+      return {
+        content: [{
+          type: 'text',
+          text: `Research started. ID: ${interaction.id}\nStatus: ${interaction.status}\nUse research_status to check progress.`
+        }]
+      };
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      const isQuotaError = message.includes('429') || message.toLowerCase().includes('quota') || message.toLowerCase().includes('too many requests');
+
+      if (isQuotaError) {
+        return {
+          isError: true,
+          content: [{
+            type: 'text',
+            text: `Deep Research quota error: ${message}\n\n` +
+              `This typically means your API key does not have access to the Deep Research feature.\n` +
+              `Deep Research requires a paid Google AI API key — free-tier keys do not have quota for this feature.\n\n` +
+              `To resolve this:\n` +
+              `1. Ensure you have a paid API key from Google AI Studio (https://aistudio.google.com/apikey)\n` +
+              `2. Verify billing is enabled on your Google Cloud project\n` +
+              `3. Set the key via GEMINI_DEEP_RESEARCH_API_KEY or GEMINI_API_KEY environment variable`,
+          }],
+        };
+      }
+
+      return {
+        isError: true,
+        content: [{ type: 'text', text: `Research failed to start: ${message}` }],
+      };
     }
-    return { 
-      content: [{ 
-        type: 'text', 
-        text: `Research started. ID: ${interaction.id}\nStatus: ${interaction.status}\nUse research_status to check progress.` 
-      }] 
-    };
   }
 );
 


### PR DESCRIPTION
## Summary
- Detect 429/quota errors in `research_start` and return an actionable message explaining that Deep Research requires a paid API key (free-tier keys lack Interactions API quota)
- Add retry with exponential backoff (up to 3 retries) for transient errors (temporary 429s, 503s, network errors) in `ResearchManager.startResearch()` — quota/billing errors are not retried
- Document the paid API key requirement in README and extension docs (`deep-research-GEMINI.md`)

Closes #30

## Test plan
- [x] Existing tests pass (38/38 in deep-research, 221/221 in gemini-utils)
- [x] New tests added for quota error → helpful message, generic quota error → helpful message, non-quota error → generic error
- [x] Both projects build cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated API key requirements clarifying that a paid Google AI API key is needed
  * Added environment variable setup instructions and default model configuration details

* **Bug Fixes**
  * Enhanced error handling with detailed messages for quota-related issues
  * Improved error responses to better guide users when quota limits are encountered

<!-- end of auto-generated comment: release notes by coderabbit.ai -->