### PR TITLE
chore(deps): bump @allenhutchison/gemini-utils to ^0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.10",
       "license": "ISC",
       "dependencies": {
-        "@allenhutchison/gemini-utils": "^0.5.0",
+        "@allenhutchison/gemini-utils": "^0.6.0",
         "@google/genai": "^1.48.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.3.6"
@@ -30,9 +30,9 @@
       }
     },
     "node_modules/@allenhutchison/gemini-utils": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@allenhutchison/gemini-utils/-/gemini-utils-0.5.0.tgz",
-      "integrity": "sha512-xhKXmuFeDTv/MNh+qsXeQidysdUEXg5f7+AVy7JmvVazx6Gyp8XS0/3rYArK7J8OcD9fbw2iqN5qVFh2WO/OCg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@allenhutchison/gemini-utils/-/gemini-utils-0.6.0.tgz",
+      "integrity": "sha512-Fbllxagk9lfpOn7eF9e90CF0xsgNlopd0Cl/gve7NqT5m+iwuWhx7+YE6NkvZ3cE8HYxNaRRiu1ha35FTro9Tg==",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "typescript-eslint": "^8.58.1"
   },
   "dependencies": {
-    "@allenhutchison/gemini-utils": "^0.5.0",
+    "@allenhutchison/gemini-utils": "^0.6.0",
     "@google/genai": "^1.48.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^4.3.6"


### PR DESCRIPTION
## Summary
- Bumps `@allenhutchison/gemini-utils` from `^0.5.0` to `^0.6.0` (released 2026-05-03).

## Test plan
- [x] `npm install` resolves cleanly
- [x] `npm run build` succeeds
- [x] `npm test` — 38 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `gemini-utils` dependency to version 0.6.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->