### PR TITLE
feat: auto-write research report via outputPath on research_start

### DIFF
--- a/commands/deep-research/start.toml
+++ b/commands/deep-research/start.toml
@@ -42,5 +42,6 @@ Suggest one of the following output formats to the user, or ask them to define t
 Once the user confirms the detailed prompt and format:
 1. Check for available file search stores using `file_search_list_stores`.
 2. Ask if they want to include specific stores for grounding.
-3. Call `research_start` with the *refined, detailed prompt* (including the formatting instructions) and any selected store names.
+3. Ask the user where they'd like the report written (default: `research-report.md` in the current directory).
+4. Call `research_start` with the *refined, detailed prompt* (including the formatting instructions), any selected store names, and the chosen `outputPath`. The server will poll in the background and write the file automatically when research finishes (10–30 minutes typical) — the user can keep working in the meantime.
 """

--- a/deep-research-GEMINI.md
+++ b/deep-research-GEMINI.md
@@ -30,9 +30,9 @@ The extension automatically manages a `.gemini-research.json` file in the curren
 - `file_search_query`: Ask a specific question against a file search store for grounded answers.
 
 ### Deep Research
-- `research_start`: Start a long-running background research task. You can ground it in your uploaded files by providing `fileSearchStoreNames`. Use `report_format` to specify the desired output structure (e.g., "Executive Brief", "Technical Deep Dive", "Comprehensive Research Report").
-- `research_status`: Check if the research is done and retrieve the results.
-- `research_save_report`: Once completed, save the findings as a professional Markdown report.
+- `research_start`: Start a long-running background research task. You can ground it in your uploaded files by providing `fileSearchStoreNames`. Use `report_format` to specify the desired output structure (e.g., "Executive Brief", "Technical Deep Dive", "Comprehensive Research Report"). Pass `outputPath` to have the server write the markdown report to that file automatically when research completes — recommended for the typical "kick it off and come back later" flow, since it removes the need for the agent to poll or save explicitly.
+- `research_status`: Check if the research is done and retrieve the results. Only needed when `outputPath` was *not* given to `research_start`, or when the user wants a progress update mid-flight.
+- `research_save_report`: Save the findings as a Markdown report. Only needed when `outputPath` was not given to `research_start`, or when the user wants a second copy in a different location.
 
 ## Tool Dependencies & Workflow
 
@@ -48,7 +48,8 @@ When performing research or querying data, strictly follow this ordering:
     -   For direct questions about specific files: Use `file_search_query`.
 
 3.  **Completion**:
-    -   For deep research, use `research_status` to monitor progress.
-    -   Finalize by generating a report with `research_save_report`.
+    -   Preferred: pass `outputPath` to `research_start` so the report writes itself when research finishes (10–30 minutes typical). The user can keep working in the meantime; when they ask about the results, read the file.
+    -   Fallback (no `outputPath`): use `research_status` to monitor and `research_save_report` to write the markdown when status is `completed`.
+    -   On failure with `outputPath` set, the file is still written but contains an error message and the interaction ID, which can be passed to `research_status` for further inspection.
 
 Always provide the user with the Research ID or Store Name when initiating background tasks or creating resources.

--- a/deep-research-GEMINI.md
+++ b/deep-research-GEMINI.md
@@ -49,7 +49,7 @@ When performing research or querying data, strictly follow this ordering:
 
 3.  **Completion**:
     -   Preferred: pass `outputPath` to `research_start` so the report writes itself when research finishes (10–30 minutes typical). The user can keep working in the meantime; when they ask about the results, read the file.
-    -   Fallback (no `outputPath`): use `research_status` to monitor and `research_save_report` to write the markdown when status is `completed`.
+    -   Fallback (no `outputPath`): use `research_status` to monitor and `research_save_report` to write the Markdown when status is `completed`.
     -   On failure with `outputPath` set, the file is still written but contains an error message and the interaction ID, which can be passed to `research_status` for further inspection.
 
 Always provide the user with the Research ID or Store Name when initiating background tasks or creating resources.

--- a/src/ResearchWatcher.test.ts
+++ b/src/ResearchWatcher.test.ts
@@ -55,7 +55,7 @@ describe('ResearchWatcher', () => {
     mockGenerateMarkdown = jest.fn();
   });
 
-  function makeWatcher() {
+  function makeWatcher(): InstanceType<typeof ResearchWatcher> {
     return new ResearchWatcher({
       researchManager: { poll: mockPoll as never },
       reportGenerator: { generateMarkdown: mockGenerateMarkdown as never },

--- a/src/ResearchWatcher.test.ts
+++ b/src/ResearchWatcher.test.ts
@@ -1,0 +1,188 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import path from 'path';
+
+const mockWriteFileSync = jest.fn();
+const mockExistsSync = jest.fn(() => true);
+const mockReadFileSync = jest.fn(() => JSON.stringify({
+  researchIds: [],
+  fileSearchStores: {},
+  uploadOperations: {},
+  pendingResearch: {},
+}));
+
+jest.unstable_mockModule('fs', () => ({
+  default: {
+    existsSync: mockExistsSync,
+    readFileSync: mockReadFileSync,
+    writeFileSync: mockWriteFileSync,
+  },
+  existsSync: mockExistsSync,
+  readFileSync: mockReadFileSync,
+  writeFileSync: mockWriteFileSync,
+}));
+
+const { ResearchWatcher } = await import('./ResearchWatcher');
+const { WorkspaceConfigManager } = await import('./config/WorkspaceConfig');
+
+describe('ResearchWatcher', () => {
+  const workspaceRoot = '/tmp/research-watcher-test';
+
+  let configState: Record<string, { outputPath: string }>;
+  let mockPoll: jest.Mock;
+  let mockGenerateMarkdown: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    configState = {};
+
+    // Bare minimum stub: pendingResearch round-trips through fs mocks.
+    mockReadFileSync.mockImplementation(() =>
+      JSON.stringify({
+        researchIds: [],
+        fileSearchStores: {},
+        uploadOperations: {},
+        pendingResearch: configState,
+      }),
+    );
+    mockWriteFileSync.mockImplementation((_path: unknown, content: unknown) => {
+      if (typeof _path === 'string' && _path.endsWith('.gemini-research.json')) {
+        const parsed = JSON.parse(content as string);
+        configState = parsed.pendingResearch ?? {};
+      }
+    });
+
+    mockPoll = jest.fn();
+    mockGenerateMarkdown = jest.fn();
+  });
+
+  function makeWatcher() {
+    return new ResearchWatcher({
+      researchManager: { poll: mockPoll as never },
+      reportGenerator: { generateMarkdown: mockGenerateMarkdown as never },
+      pollIntervalMs: 1,
+      workspaceRoot,
+    });
+  }
+
+  it('writes the markdown report and clears pending state when research completes', async () => {
+    mockPoll.mockResolvedValue({
+      id: 'r-1',
+      status: 'completed',
+      outputs: [{ kind: 'text', text: 'hello' }],
+    } as never);
+    mockGenerateMarkdown.mockReturnValue('# Report' as never);
+
+    const watcher = makeWatcher();
+    watcher.track('r-1', 'report.md');
+    await watcher.settle();
+
+    const reportWrite = mockWriteFileSync.mock.calls.find(
+      ([p]) => p === path.resolve(workspaceRoot, 'report.md'),
+    );
+    expect(reportWrite).toBeDefined();
+    expect(reportWrite?.[1]).toBe('# Report');
+    expect(configState).toEqual({});
+  });
+
+  it('writes an error file with the interaction ID when research fails', async () => {
+    mockPoll.mockResolvedValue({
+      id: 'r-2',
+      status: 'failed',
+      outputs: [],
+    } as never);
+
+    const watcher = makeWatcher();
+    watcher.track('r-2', '/abs/report.md');
+    await watcher.settle();
+
+    const errorWrite = mockWriteFileSync.mock.calls.find(([p]) => p === '/abs/report.md');
+    expect(errorWrite).toBeDefined();
+    const body = errorWrite?.[1] as string;
+    expect(body).toContain('Interaction ID: r-2');
+    expect(body).toContain('research_status id="r-2"');
+    expect(body).toContain('"failed"');
+    expect(configState).toEqual({});
+  });
+
+  it('writes an error file when poll throws', async () => {
+    mockPoll.mockRejectedValue(new Error('network down') as never);
+
+    const watcher = makeWatcher();
+    watcher.track('r-3', 'report.md');
+    await watcher.settle();
+
+    const errorWrite = mockWriteFileSync.mock.calls.find(
+      ([p]) => p === path.resolve(workspaceRoot, 'report.md'),
+    );
+    expect(errorWrite).toBeDefined();
+    const body = errorWrite?.[1] as string;
+    expect(body).toContain('network down');
+    expect(body).toContain('Interaction ID: r-3');
+    expect(configState).toEqual({});
+  });
+
+  it('writes an error file when status is completed but outputs are missing', async () => {
+    mockPoll.mockResolvedValue({ id: 'r-4', status: 'completed' } as never);
+
+    const watcher = makeWatcher();
+    watcher.track('r-4', 'report.md');
+    await watcher.settle();
+
+    const write = mockWriteFileSync.mock.calls.find(
+      ([p]) => p === path.resolve(workspaceRoot, 'report.md'),
+    );
+    expect(write?.[1]).toContain('returned no outputs');
+  });
+
+  it('persists pending research before polling so it can resume after a restart', async () => {
+    let resolvePoll!: (v: unknown) => void;
+    mockPoll.mockReturnValue(new Promise((r) => { resolvePoll = r; }) as never);
+
+    const watcher = makeWatcher();
+    watcher.track('r-5', 'report.md');
+
+    // While the poll is in flight, pending state should include r-5.
+    expect(configState).toEqual({ 'r-5': { outputPath: 'report.md' } });
+
+    resolvePoll({ id: 'r-5', status: 'completed', outputs: [{ kind: 'text', text: 'ok' }] });
+    mockGenerateMarkdown.mockReturnValue('done' as never);
+    await watcher.settle();
+
+    expect(configState).toEqual({});
+  });
+
+  it('resumeAll spawns watchers for every persisted pending interaction', async () => {
+    configState = {
+      'r-a': { outputPath: 'a.md' },
+      'r-b': { outputPath: 'b.md' },
+    };
+    mockPoll.mockResolvedValue({ id: 'x', status: 'failed', outputs: [] } as never);
+
+    const watcher = makeWatcher();
+    watcher.resumeAll();
+    await watcher.settle();
+
+    expect(mockPoll).toHaveBeenCalledTimes(2);
+    expect(mockPoll.mock.calls.map((c) => c[0])).toEqual(expect.arrayContaining(['r-a', 'r-b']));
+  });
+
+  it('track is idempotent — calling twice for the same id does not double-poll', async () => {
+    mockPoll.mockResolvedValue({
+      id: 'r-6',
+      status: 'completed',
+      outputs: [{ kind: 'text', text: 'x' }],
+    } as never);
+    mockGenerateMarkdown.mockReturnValue('# r' as never);
+
+    const watcher = makeWatcher();
+    watcher.track('r-6', 'report.md');
+    watcher.track('r-6', 'report.md');
+    await watcher.settle();
+
+    expect(mockPoll).toHaveBeenCalledTimes(1);
+  });
+});
+
+// Silence the assertion: WorkspaceConfigManager isn't directly under test here
+// but keeping the import live ensures the schema accepts pendingResearch.
+void WorkspaceConfigManager;

--- a/src/ResearchWatcher.ts
+++ b/src/ResearchWatcher.ts
@@ -1,0 +1,120 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  Interaction,
+  ReportGenerator,
+  ResearchManager,
+} from '@allenhutchison/gemini-utils';
+import { WorkspaceConfigManager } from './config/WorkspaceConfig.js';
+
+const DEFAULT_POLL_INTERVAL_MS = 60_000;
+
+export interface ResearchWatcherDeps {
+  researchManager: Pick<ResearchManager, 'poll'>;
+  reportGenerator: Pick<ReportGenerator, 'generateMarkdown'>;
+  pollIntervalMs?: number;
+  workspaceRoot?: string;
+}
+
+export class ResearchWatcher {
+  private readonly researchManager: ResearchWatcherDeps['researchManager'];
+  private readonly reportGenerator: ResearchWatcherDeps['reportGenerator'];
+  private readonly pollIntervalMs: number;
+  private readonly workspaceRoot: string;
+  private readonly active = new Map<string, Promise<void>>();
+
+  constructor(deps: ResearchWatcherDeps) {
+    this.researchManager = deps.researchManager;
+    this.reportGenerator = deps.reportGenerator;
+    this.pollIntervalMs = deps.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this.workspaceRoot = deps.workspaceRoot ?? process.env.GEMINI_WORKSPACE_PATH ?? '.';
+  }
+
+  /**
+   * Begins watching a research interaction. Persists the (id, outputPath) so
+   * the watcher can resume after a server restart, then kicks off the async
+   * poll loop. Returns immediately.
+   */
+  track(id: string, outputPath: string): void {
+    WorkspaceConfigManager.addPendingResearch(id, outputPath);
+    this.spawn(id, outputPath);
+  }
+
+  /**
+   * Resumes watchers for any research interactions that were in flight when
+   * the previous server process exited. Safe to call on startup.
+   */
+  resumeAll(): void {
+    const pending = WorkspaceConfigManager.getAllPendingResearch();
+    for (const [id, { outputPath }] of Object.entries(pending)) {
+      this.spawn(id, outputPath);
+    }
+  }
+
+  /**
+   * For tests: returns a promise that resolves when all in-flight watcher
+   * tasks have settled.
+   */
+  async settle(): Promise<void> {
+    await Promise.all(this.active.values());
+  }
+
+  private spawn(id: string, outputPath: string): void {
+    if (this.active.has(id)) return;
+    const task = this.run(id, outputPath).finally(() => {
+      this.active.delete(id);
+    });
+    this.active.set(id, task);
+  }
+
+  private async run(id: string, outputPath: string): Promise<void> {
+    const resolved = this.resolve(outputPath);
+    let interaction: Interaction;
+    try {
+      interaction = await this.researchManager.poll(id, this.pollIntervalMs);
+    } catch (err) {
+      this.writeError(resolved, id, err instanceof Error ? err.message : String(err));
+      WorkspaceConfigManager.removePendingResearch(id);
+      return;
+    }
+
+    if (interaction.status === 'completed' && interaction.outputs) {
+      try {
+        const markdown = this.reportGenerator.generateMarkdown(interaction.outputs);
+        fs.writeFileSync(resolved, markdown);
+      } catch (err) {
+        this.writeError(resolved, id, err instanceof Error ? err.message : String(err));
+      }
+    } else {
+      const reason =
+        interaction.status === 'completed'
+          ? 'Research completed but returned no outputs.'
+          : `Research ended with status "${interaction.status ?? 'unknown'}".`;
+      this.writeError(resolved, id, reason);
+    }
+    WorkspaceConfigManager.removePendingResearch(id);
+  }
+
+  private resolve(outputPath: string): string {
+    return path.isAbsolute(outputPath)
+      ? outputPath
+      : path.resolve(this.workspaceRoot, outputPath);
+  }
+
+  private writeError(resolved: string, id: string, message: string): void {
+    const body = [
+      `Deep Research did not produce a report.`,
+      ``,
+      `Reason: ${message}`,
+      ``,
+      `Interaction ID: ${id}`,
+      `You can query the API directly with: research_status id="${id}"`,
+      ``,
+    ].join('\n');
+    try {
+      fs.writeFileSync(resolved, body);
+    } catch (err) {
+      console.error(`[research-watcher] failed to write error file ${resolved}:`, err);
+    }
+  }
+}

--- a/src/config/WorkspaceConfig.test.ts
+++ b/src/config/WorkspaceConfig.test.ts
@@ -28,6 +28,7 @@ describe('WorkspaceConfigManager', () => {
       'my-store': 'stores/store-456',
     },
     uploadOperations: {},
+    pendingResearch: {},
   };
 
   beforeEach(() => {
@@ -47,7 +48,7 @@ describe('WorkspaceConfigManager', () => {
     mockExistsSync.mockReturnValue(false);
 
     const config = WorkspaceConfigManager.load();
-    expect(config).toEqual({ researchIds: [], fileSearchStores: {}, uploadOperations: {} });
+    expect(config).toEqual({ researchIds: [], fileSearchStores: {}, uploadOperations: {}, pendingResearch: {} });
   });
 
   it('should save config', () => {
@@ -89,7 +90,7 @@ describe('WorkspaceConfigManager', () => {
 
     const config = WorkspaceConfigManager.load();
 
-    expect(config).toEqual({ researchIds: [], fileSearchStores: {}, uploadOperations: {} });
+    expect(config).toEqual({ researchIds: [], fileSearchStores: {}, uploadOperations: {}, pendingResearch: {} });
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining('Failed to load workspace config'),
       expect.anything()
@@ -105,7 +106,7 @@ describe('WorkspaceConfigManager', () => {
 
     const config = WorkspaceConfigManager.load();
 
-    expect(config).toEqual({ researchIds: [], fileSearchStores: {}, uploadOperations: {} });
+    expect(config).toEqual({ researchIds: [], fileSearchStores: {}, uploadOperations: {}, pendingResearch: {} });
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining('Failed to load workspace config'),
       expect.anything()

--- a/src/config/WorkspaceConfig.ts
+++ b/src/config/WorkspaceConfig.ts
@@ -28,10 +28,17 @@ const UploadOperationSchema = z.object({
   error: z.string().optional(),
 });
 
+const PendingResearchSchema = z.object({
+  outputPath: z.string(),
+});
+
+export type PendingResearch = z.infer<typeof PendingResearchSchema>;
+
 export const WorkspaceConfigSchema = z.object({
   researchIds: z.array(z.string()).default([]),
   fileSearchStores: z.record(z.string(), z.string()).default({}),
   uploadOperations: z.record(z.string(), UploadOperationSchema).default({}),
+  pendingResearch: z.record(z.string(), PendingResearchSchema).default({}),
 });
 
 export type WorkspaceConfig = z.infer<typeof WorkspaceConfigSchema>;
@@ -41,7 +48,7 @@ export class WorkspaceConfigManager {
 
   static load(): WorkspaceConfig {
     if (!fs.existsSync(this.configPath)) {
-      const defaultConfig: WorkspaceConfig = { researchIds: [], fileSearchStores: {}, uploadOperations: {} };
+      const defaultConfig: WorkspaceConfig = { researchIds: [], fileSearchStores: {}, uploadOperations: {}, pendingResearch: {} };
       this.save(defaultConfig);
       return defaultConfig;
     }
@@ -53,7 +60,7 @@ export class WorkspaceConfigManager {
     } catch (error) {
       // If file is corrupt, safer to return default to avoid crashing, but warn the user
       console.warn(`Failed to load workspace config from ${this.configPath}:`, error);
-      return { researchIds: [], fileSearchStores: {}, uploadOperations: {} };
+      return { researchIds: [], fileSearchStores: {}, uploadOperations: {}, pendingResearch: {} };
     }
   }
 
@@ -89,6 +96,25 @@ export class WorkspaceConfigManager {
   static getAllUploadOperations(): Record<string, UploadOperation> {
     const config = this.load();
     return config.uploadOperations;
+  }
+
+  static addPendingResearch(id: string, outputPath: string): void {
+    const config = this.load();
+    config.pendingResearch[id] = { outputPath };
+    this.save(config);
+  }
+
+  static removePendingResearch(id: string): void {
+    const config = this.load();
+    if (config.pendingResearch[id]) {
+      delete config.pendingResearch[id];
+      this.save(config);
+    }
+  }
+
+  static getAllPendingResearch(): Record<string, PendingResearch> {
+    const config = this.load();
+    return config.pendingResearch;
   }
 }
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -16,6 +16,7 @@ const mockUpdateProgress = jest.fn();
 const mockAddFailedFile = jest.fn();
 const mockStartResearch = jest.fn();
 const mockGetStatus = jest.fn();
+const mockPoll = jest.fn();
 const mockGenerateMarkdown = jest.fn();
 
 jest.unstable_mockModule('@allenhutchison/gemini-utils', () => ({
@@ -41,6 +42,7 @@ jest.unstable_mockModule('@allenhutchison/gemini-utils', () => ({
   ResearchManager: jest.fn().mockImplementation(() => ({
     startResearch: mockStartResearch,
     getStatus: mockGetStatus,
+    poll: mockPoll,
   })),
   ReportGenerator: jest.fn().mockImplementation(() => ({
     generateMarkdown: mockGenerateMarkdown,
@@ -77,12 +79,18 @@ jest.unstable_mockModule('fs', () => ({
 const mockAddFileSearchStore = jest.fn();
 const mockAddResearchId = jest.fn();
 const mockLoad = jest.fn();
+const mockAddPendingResearch = jest.fn();
+const mockRemovePendingResearch = jest.fn();
+const mockGetAllPendingResearch = jest.fn(() => ({}));
 
 jest.unstable_mockModule('./config/WorkspaceConfig.js', () => ({
   WorkspaceConfigManager: {
     addFileSearchStore: mockAddFileSearchStore,
     addResearchId: mockAddResearchId,
     load: mockLoad,
+    addPendingResearch: mockAddPendingResearch,
+    removePendingResearch: mockRemovePendingResearch,
+    getAllPendingResearch: mockGetAllPendingResearch,
   },
   WorkspaceOperationStorage: jest.fn(),
 }));
@@ -489,6 +497,43 @@ describe('MCP Server Tools', () => {
       expect(result.content[0].text).toContain('Research failed to start');
       expect(result.content[0].text).toContain('Network connection failed');
       expect(result.content[0].text).not.toContain('paid Google AI API key');
+    });
+
+    it('registers a background watcher and reports the output path when outputPath is provided', async () => {
+      mockStartResearch.mockResolvedValue({
+        id: 'research-out-1',
+        status: 'in_progress',
+      });
+      // Keep the poll pending so the watcher doesn't try to write a file
+      // during this test (we cover the write path in ResearchWatcher.test.ts).
+      mockPoll.mockReturnValue(new Promise(() => {}));
+
+      const result = await toolHandlers['research_start']({
+        input: 'Research with output path',
+        model: 'deep-research-pro-preview-12-2025',
+        outputPath: 'reports/out.md',
+      }) as McpToolResult;
+
+      expect(mockAddResearchId).toHaveBeenCalledWith('research-out-1');
+      expect(mockAddPendingResearch).toHaveBeenCalledWith('research-out-1', 'reports/out.md');
+      expect(mockPoll).toHaveBeenCalledWith('research-out-1', expect.any(Number));
+      expect(result.content[0].text).toContain('reports/out.md');
+      expect(result.content[0].text).not.toContain('Use research_status to check progress');
+    });
+
+    it('does not register a watcher when outputPath is omitted', async () => {
+      mockStartResearch.mockResolvedValue({
+        id: 'research-noop-1',
+        status: 'in_progress',
+      });
+
+      await toolHandlers['research_start']({
+        input: 'Research without output path',
+        model: 'deep-research-pro-preview-12-2025',
+      });
+
+      expect(mockAddPendingResearch).not.toHaveBeenCalled();
+      expect(mockPoll).not.toHaveBeenCalled();
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
   ReportGenerator,
 } from '@allenhutchison/gemini-utils';
 import { WorkspaceConfigManager, WorkspaceOperationStorage } from './config/WorkspaceConfig.js';
+import { ResearchWatcher } from './ResearchWatcher.js';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -68,6 +69,17 @@ function getResearchManager(): ResearchManager {
 
 const uploadOperationManager = new UploadOperationManager(new WorkspaceOperationStorage());
 const reportGenerator = new ReportGenerator();
+
+let _researchWatcher: ResearchWatcher | undefined;
+function getResearchWatcher(): ResearchWatcher {
+  if (!_researchWatcher) {
+    _researchWatcher = new ResearchWatcher({
+      researchManager: getResearchManager(),
+      reportGenerator,
+    });
+  }
+  return _researchWatcher;
+}
 
 declare const PKG_VERSION: string;
 
@@ -303,15 +315,16 @@ server.registerTool(
 server.registerTool(
   'research_start',
   {
-    description: 'Starts a new Deep Research interaction in the background.',
+    description: 'Starts a new Deep Research interaction in the background. If outputPath is provided, the server polls the API on its own and writes the markdown report to that path when the interaction completes — no follow-up tool call required.',
     inputSchema: z.object({
       input: z.string().describe('The research query or instructions'),
       report_format: z.string().optional().describe('The desired format of the report (e.g., "Executive Brief", "Technical Deep Dive", "Comprehensive Research Report")'),
       model: z.string().optional().default('deep-research-pro-preview-12-2025').describe('The agent to use (default: deep-research-pro-preview-12-2025)'),
       fileSearchStoreNames: z.array(z.string()).optional().describe('Optional list of file search store names for grounding'),
+      outputPath: z.string().optional().describe('Optional path to write the markdown report to when research completes. The server polls in the background and writes the file automatically; on failure, an error message including the interaction ID is written instead.'),
     }).shape,
   },
-  async ({ input, report_format, model, fileSearchStoreNames }) => {
+  async ({ input, report_format, model, fileSearchStoreNames, outputPath }) => {
     let finalInput = input;
     if (report_format) {
       finalInput = `[Report Format: ${report_format}]\n\n${input}`;
@@ -325,11 +338,17 @@ server.registerTool(
       });
       if (interaction.id) {
           WorkspaceConfigManager.addResearchId(interaction.id);
+          if (outputPath) {
+            getResearchWatcher().track(interaction.id, outputPath);
+          }
       }
+      const followUp = outputPath
+        ? `The report will be written to ${outputPath} when research completes.`
+        : `Use research_status to check progress.`;
       return {
         content: [{
           type: 'text',
-          text: `Research started. ID: ${interaction.id}\nStatus: ${interaction.status}\nUse research_status to check progress.`
+          text: `Research started. ID: ${interaction.id}\nStatus: ${interaction.status}\n${followUp}`
         }]
       };
     } catch (error: unknown) {
@@ -410,6 +429,17 @@ async function main(): Promise<void> {
   WorkspaceConfigManager.load();
   await server.connect(transport);
   console.error('Gemini Deep Research MCP server running on stdio');
+
+  // Resume background polling for any research interactions that were
+  // in flight when the previous server process exited. Only attempt this
+  // when an API key is configured, so we don't crash startup on misconfig.
+  if (apiKey) {
+    try {
+      getResearchWatcher().resumeAll();
+    } catch (err) {
+      console.error('Failed to resume in-flight research watchers:', err);
+    }
+  }
 }
 
 main().catch((error) => {


### PR DESCRIPTION
Closes #22.

## The CUJ this fixes

Today, after `research_start` returns, the agent has to keep calling `research_status` until status is `completed`, then explicitly call `research_save_report`. Deep Research takes 10–30 minutes, so if the user walks away and comes back, nothing has happened — the agent doesn't autonomously poll, and any interim "are you done yet?" check forces the user to drive the loop manually.

## The change

`research_start` gets an optional `outputPath` parameter. When provided, the MCP server polls the API on its own (via `ResearchManager.poll()` from `gemini-utils`) and writes the markdown report to `outputPath` on completion. The user can keep working in the same session and the file just appears when ready. When they later ask about the results, the agent reads the file.

- `research_save_report` stays as-is. It's still useful when no `outputPath` was provided up front, or for writing a second copy somewhere else.
- On failure, we still write to `outputPath` — but the body is an error message that includes the interaction ID, so the user can pass it back to `research_status` if they want to debug.
- `{id → outputPath}` is persisted in `.gemini-research.json` (`pendingResearch` field). On startup, the MCP server resumes pollers for any in-flight research from a prior session, closing the "I closed the terminal mid-research" gap.
- Polling interval: 60s (no config knob — agreed in design discussion that this is fine).

## What did NOT change

- No hooks, no detached subprocesses, no terminal-notifier dependency. Polling lives inside the long-running MCP server.
- `research_status` and `research_save_report` are unchanged for backward compatibility. Existing workflows keep working.

## Files

- `src/ResearchWatcher.ts` — new module wrapping `ResearchManager.poll()` with the file-write + error-write + persistence logic.
- `src/ResearchWatcher.test.ts` — 7 unit tests covering completion, three failure modes, persistence, resume-on-startup, and idempotent `track()`.
- `src/config/WorkspaceConfig.ts` — `pendingResearch` field + `addPendingResearch` / `removePendingResearch` / `getAllPendingResearch`.
- `src/index.ts` — `outputPath` param on `research_start`, watcher wiring, `resumeAll()` on startup.
- `src/index.test.ts` — 2 new tests for the `outputPath` plumbing.
- `deep-research-GEMINI.md` and `commands/deep-research/start.toml` — steer the agent toward the new flow.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 47 passing (38 existing + 9 new)
- [ ] Manual: run extension locally, kick off a real research job with `outputPath`, walk away for 10+ minutes, confirm file appears
- [ ] Manual: kill the MCP server mid-research, restart, confirm pending research resumes and file is eventually written

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Deep Research now prompts you to specify where the generated report should be written (defaults to `research-report.md`).
  * Reports are automatically written to the specified output path upon completion, eliminating manual polling or saving steps.

* **Documentation**
  * Updated Deep Research documentation to describe the new output path-driven workflow and fallback options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->